### PR TITLE
fix(logging): write dev-log entries to files instead of directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 dist/
+
+# Generated development logs and artifacts
+.kiro/development-log/analysis-*.md
+*.backup.*

--- a/.kiro/development-log/dev-log-2026-01-08.md
+++ b/.kiro/development-log/dev-log-2026-01-08.md
@@ -65,3 +65,25 @@
 - Commit: N/A
 - Analysis Time: 1767880421367ms
 - Version: 1.0.0
+## Log Entry: entry-1767895421508-4ik4j4ehu
+
+**Timestamp:** 2026-01-08T18:03:41.508Z
+
+**Session:** session-1767895421508-be60m457h
+
+**Trigger:** manual
+
+**Changes:**
+- Added feature: analyzer - Updated CodeAnalyzer class with 0 methods
+- component-modified: analyzer - Component modified: analyzer
+
+**Affected Files:**
+- src/analysis/analyzer.ts
+
+**Rationale:** Initialization error test
+
+**Metadata:**
+- Author: Unknown
+- Commit: N/A
+- Analysis Time: 1767895421508ms
+- Version: 1.0.0

--- a/src/analysis/analyzer.ts
+++ b/src/analysis/analyzer.ts
@@ -636,9 +636,13 @@ export class CodeAnalyzer {
 
     // Development log entry
     if (apis.length > 0 || features.length > 0 || changes.length > 0) {
+      // Generate a timestamped filename for the development log
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const filename = `analysis-${timestamp}.md`;
+      
       requirements.push({
         type: 'dev-log',
-        targetFile: '.kiro/development-log/',
+        targetFile: `.kiro/development-log/${filename}`,
         content: `Development log entry for analysis results`,
         priority: 'low'
       });


### PR DESCRIPTION
- Fixed CodeAnalyzer.generateDocumentationRequirements() to generate timestamped filenames
- Updated targetFile to use .kiro/development-log/<filename> instead of directory path
- Prevents EISDIR crashes when OutputManager attempts atomic writes to directories
- Added .gitignore patterns for generated artifacts

Resolves issue with OutputManager.writeDocumentation() directory writes