### PR TITLE
fix(config): honor configured workspace paths instead of hardcoded .kiro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules/
 dist/
 
 # Generated development logs and artifacts
-.kiro/development-log/analysis-*.md
+.kiro/development-log/*.md
 *.backup.*

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { AutoDocSyncSystem } from './orchestrator';
 interface CLIOptions {
   trigger: 'git-hook' | 'manual';
   config?: string;
+  workspace?: string;
   files?: string[];
   reason?: string;
   help?: boolean;
@@ -37,6 +38,8 @@ function parseArguments(): CLIOptions {
       }
     } else if (arg.startsWith('--config=')) {
       options.config = arg.split('=')[1];
+    } else if (arg.startsWith('--workspace=')) {
+      options.workspace = arg.split('=')[1];
     } else if (arg.startsWith('--reason=')) {
       options.reason = arg.split('=')[1];
     } else if (arg.startsWith('--file=')) {
@@ -66,6 +69,7 @@ USAGE:
 OPTIONS:
   --trigger=TYPE        Trigger type: 'manual' (default) or 'git-hook'
   --config=PATH         Path to configuration file
+  --workspace=PATH      Workspace root directory (default: current directory)
   --reason=TEXT         Reason for manual trigger (for logging)
   --file=PATH           Specific file to analyze (can be used multiple times)
   --files=PATH1,PATH2   Comma-separated list of files to analyze
@@ -149,7 +153,7 @@ async function main(): Promise<void> {
 
     console.log('🚀 Starting Auto-Doc-Sync System...');
     
-    const system = new AutoDocSyncSystem(options.config);
+    const system = new AutoDocSyncSystem(options.config, options.workspace);
     
     await system.run({
       triggerType: options.trigger,

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,7 @@ export class ConfigManager {
    */
   static getDefaultConfig(): SystemConfig {
     return {
+      workspaceRoot: process.cwd(),
       analysis: {
         includePatterns: [
           '**/*.ts',
@@ -123,6 +124,11 @@ export class ConfigManager {
   static validateConfig(config: any): ConfigValidationResult {
     const errors: string[] = [];
     const warnings: string[] = [];
+
+    // Validate workspace root
+    if (config.workspaceRoot && typeof config.workspaceRoot !== 'string') {
+      errors.push('workspaceRoot must be a string');
+    }
 
     // Validate analysis configuration
     if (config.analysis) {
@@ -204,6 +210,7 @@ export class ConfigManager {
    */
   private static mergeConfigs(defaultConfig: SystemConfig, userConfig: any): SystemConfig {
     return {
+      workspaceRoot: userConfig.workspaceRoot || defaultConfig.workspaceRoot,
       analysis: {
         ...defaultConfig.analysis,
         ...userConfig.analysis

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,15 +18,17 @@ export { AutoDocSyncSystem };
 // CLI entry point
 export async function main(): Promise<void> {
   const args = process.argv.slice(2);
-  const system = new AutoDocSyncSystem();
+  
+  // Parse command line arguments
+  const triggerType = args.find(arg => arg.startsWith('--trigger='))?.split('=')[1] as 'git-hook' | 'manual' || 'manual';
+  const configPath = args.find(arg => arg.startsWith('--config='))?.split('=')[1];
+  const workspaceRoot = args.find(arg => arg.startsWith('--workspace='))?.split('=')[1];
+  const targetFiles = args.filter(arg => arg.startsWith('--file=')).map(arg => arg.split('=')[1]);
+  
+  const system = new AutoDocSyncSystem(configPath, workspaceRoot);
   
   try {
     await system.initialize();
-    
-    // Parse command line arguments
-    const triggerType = args.find(arg => arg.startsWith('--trigger='))?.split('=')[1] as 'git-hook' | 'manual' || 'manual';
-    const configPath = args.find(arg => arg.startsWith('--config='))?.split('=')[1];
-    const targetFiles = args.filter(arg => arg.startsWith('--file=')).map(arg => arg.split('=')[1]);
     
     await system.run({
       triggerType,

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -109,6 +109,7 @@ npm install
       // Create test configuration that points to our test workspace
       const configFile = path.join(testKiroDir, 'auto-doc-sync.json');
       await fs.writeFile(configFile, JSON.stringify({
+        workspaceRoot: testWorkspace,
         analysis: {
           includePatterns: ['**/*.ts', '**/*.js'],
           excludePatterns: ['**/node_modules/**', '**/test-*/**'],
@@ -121,7 +122,7 @@ npm install
           validateOutput: true
         },
         logging: {
-          logDirectory: path.join(testKiroDir, 'development-log'),
+          logDirectory: '.kiro/development-log',
           maxEntriesPerFile: 100,
           retentionDays: 30,
           groupingTimeWindow: 5
@@ -131,12 +132,12 @@ npm install
         },
         hooks: {
           enabled: false,
-          configPath: path.join(testKiroDir, 'hooks')
+          configPath: '.kiro/hooks'
         }
       }, null, 2));
 
       // Run the auto-doc-sync system with manual trigger
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
       
       await system.run({
@@ -204,7 +205,7 @@ npm install
       }, null, 2));
 
       // Run system
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
       
       await system.run({
@@ -272,7 +273,7 @@ export function processData(input: string): string {
       }, null, 2));
 
       // Test manual trigger
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
       
       await system.run({
@@ -332,7 +333,7 @@ export function processData(input: string): string {
       }, null, 2));
 
       // Run system with specific file targeting
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
       
       await system.run({
@@ -383,7 +384,7 @@ export function processData(input: string): string {
         }
       }, null, 2));
 
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
 
       // Test with non-existent target files
@@ -479,7 +480,7 @@ export class UserManagementService {
       }, null, 2));
 
       // Run system
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
       
       await system.run({
@@ -580,7 +581,7 @@ export class FeatureService {
       }, null, 2));
 
       // Run system
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
       
       await system.run({
@@ -639,7 +640,7 @@ export class FeatureService {
       }, null, 2));
 
       // Run system
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
       
       await system.run({
@@ -693,7 +694,7 @@ export class FeatureService {
       await fs.writeFile(sourceFile, 'export const MISSING_KIRO = true;');
 
       // Run system - should recreate directory structure
-      const system = new AutoDocSyncSystem();
+      const system = new AutoDocSyncSystem(undefined, testWorkspace);
       await system.initialize();
       
       await system.run({
@@ -753,7 +754,7 @@ export const INVALID = "unclosed string;
       }, null, 2));
 
       // Run system - should handle analysis failure gracefully
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
       
       await expect(system.run({
@@ -778,7 +779,7 @@ export const INVALID = "unclosed string;
       await fs.writeFile(sourceFile, 'export const CONFIG_ERROR = true;');
 
       // Run system - should use default config
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
       
       await expect(system.run({
@@ -822,7 +823,7 @@ export const INVALID = "unclosed string;
         }
       }, null, 2));
 
-      const system = new AutoDocSyncSystem(configFile);
+      const system = new AutoDocSyncSystem(configFile, testWorkspace);
       await system.initialize();
 
       // Test with no target files
@@ -841,7 +842,7 @@ export const INVALID = "unclosed string;
       // Create a system with invalid configuration path
       const invalidConfigPath = '/invalid/path/config.json';
       
-      const system = new AutoDocSyncSystem(invalidConfigPath);
+      const system = new AutoDocSyncSystem(invalidConfigPath, testWorkspace);
       
       // Should handle initialization gracefully
       await expect(system.initialize()).resolves.not.toThrow();


### PR DESCRIPTION
- Add workspaceRoot support to SystemConfig interface
- Update AutoDocSyncSystem constructor to accept workspace root parameter
- Add resolveWorkspacePath() helper method for path resolution
- Fix ensureDirectories() to use configured paths instead of hardcoded ones
- Update CodeAnalyzer to use path resolver for documentation requirements
- Add --workspace CLI option for specifying custom workspace roots
- Fix integration tests to use test workspace instead of project root
- Ensure constructor workspace root takes precedence over config file

Fixes issue where system always created directories in hardcoded .kiro paths instead of respecting configured workspace paths, causing integration tests to fail and preventing proper workspace isolation.