### PR TITLE
feat: add AI-powered README generation

### DIFF
--- a/.kiro/prompts/readme-generation.md
+++ b/.kiro/prompts/readme-generation.md
@@ -1,0 +1,97 @@
+You are a technical documentation expert specializing in creating compelling, user-friendly README files for open-source projects.
+
+Your task is to generate a comprehensive, well-structured README.md file based on the code analysis provided.
+
+## Analysis Data
+{analysisResults}
+
+## Existing README Content (if any)
+{existingContent}
+
+## Project Context
+{projectContext}
+
+## Your Task
+
+Generate a complete, professional README.md that includes:
+
+### 1. Project Header
+- Clear, descriptive project title
+- Concise tagline (1-2 sentences explaining what it does)
+- Relevant badges (build status, version, license, etc.)
+
+### 2. Overview Section
+- What problem does this solve?
+- Who is it for?
+- Key value proposition (why use this over alternatives?)
+
+### 3. Features Section
+- Highlight 3-5 key features with brief descriptions
+- Focus on user benefits, not just technical capabilities
+- Use clear, non-technical language where possible
+
+### 4. Installation Section
+- Prerequisites (Node.js version, dependencies, etc.)
+- Step-by-step installation instructions
+- Verification steps to confirm successful installation
+
+### 5. Quick Start / Usage Section
+- Simple, copy-paste example to get started
+- Show the most common use case
+- Include expected output
+
+### 6. Configuration Section (if applicable)
+- Configuration file format and location
+- Key configuration options with descriptions
+- Example configuration with comments
+
+### 7. API Reference (Brief)
+- Group related functions/classes logically
+- Only include public API (not internal methods)
+- Brief description for each, link to full docs if needed
+
+### 8. Examples Section
+- 2-3 real-world usage examples
+- Show different use cases
+- Include code snippets with explanations
+
+### 9. Development Section
+- How to contribute
+- How to run tests
+- Development setup instructions
+
+### 10. Additional Sections (as needed)
+- Troubleshooting / FAQ
+- Roadmap / Future plans
+- License information
+- Credits / Acknowledgments
+
+## Style Guidelines
+
+1. **Clarity over cleverness** - Use simple, direct language
+2. **Show, don't tell** - Include code examples for everything
+3. **Progressive disclosure** - Start simple, add complexity gradually
+4. **Scannable structure** - Use headings, lists, and code blocks
+5. **Consistent formatting** - Follow markdown best practices
+6. **User-focused** - Write for the reader, not the developer
+
+## Important Rules
+
+- DO NOT just dump API methods in a list
+- DO NOT include private/internal methods
+- DO NOT use overly technical jargon without explanation
+- DO include actual code examples that work
+- DO explain WHY someone would use each feature
+- DO maintain a friendly, approachable tone
+- DO preserve any custom sections from existing README
+- DO use proper markdown formatting (code blocks with language tags)
+
+## Output Format
+
+Return a complete README.md file in markdown format. Make it compelling enough that someone would want to use this project after reading it.
+
+Focus on making the README:
+- **Scannable** - Someone should understand the project in 30 seconds
+- **Actionable** - Clear next steps at every section
+- **Complete** - Everything needed to get started
+- **Professional** - Polished and well-organized

--- a/.kiro/specs/api.md
+++ b/.kiro/specs/api.md
@@ -1,6 +1,6 @@
 # API Documentation
 
-Generated: 2026-01-13T07:44:22.582Z
+Generated: 2026-01-13T08:03:57.090Z
 
 ## API Endpoints
 
@@ -36,7 +36,7 @@ Track the completion of an operation
 **Parameters:**
 - `operationId` (string) - The ID of the operation to end
 - `operationType` (OperationMetrics['type']) - The type of operation to end
-- `tokens` (number) - Optional number of tokens used in the operation
+- `tokens` (number) - Optional number of tokens consumed by the operation
 
 **Returns:** `void`
 
@@ -47,7 +47,7 @@ Track analysis run completion
 **Method:** `function`
 
 **Parameters:**
-- `filesProcessed` (number) - The number of files processed in the analysis run
+- `filesProcessed` (number) - The number of files processed during the analysis run
 
 **Returns:** `void`
 
@@ -85,120 +85,6 @@ Get current session metrics
 **Method:** `function`
 
 **Returns:** `Partial<UsageMetrics> | null`
-
-### calculateOperationCost
-
-Calculate cost for a specific operation
-
-**Method:** `function`
-
-**Parameters:**
-- `operationType` (OperationMetrics['type']) - The type of operation to calculate cost for
-- `tokens` (number) - The number of tokens used in the operation
-
-**Returns:** `number`
-
-### generateMetricsId
-
-Generate unique metrics ID
-
-**Method:** `function`
-
-**Returns:** `string`
-
-### ensureDataDirectory
-
-Ensure data directory exists
-
-**Method:** `function`
-
-**Returns:** `Promise<void>`
-
-### persistMetrics
-
-Persist metrics to file
-
-**Method:** `function`
-
-**Parameters:**
-- `metrics` (UsageMetrics) - The metrics to persist
-
-**Returns:** `Promise<void>`
-
-### loadMetricsInRange
-
-Load metrics within date range
-
-**Method:** `function`
-
-**Parameters:**
-- `startDate` (Date) - The start date of the range
-- `endDate` (Date) - The end date of the range
-
-**Returns:** `Promise<UsageMetrics[]>`
-
-### cleanupOldMetrics
-
-Clean up old metrics files
-
-**Method:** `function`
-
-**Returns:** `Promise<void>`
-
-### getEmptySummary
-
-Get empty summary for when tracking is disabled or no data exists
-
-**Method:** `function`
-
-**Returns:** `UsageSummary`
-
-### showSummary
-
-Display usage summary for the last N days
-
-**Method:** `function`
-
-**Parameters:**
-- `days` (number) - The number of days to include in the summary
-
-**Returns:** `Promise<void>`
-
-### showCurrentSession
-
-Display current session metrics (if any)
-
-**Method:** `function`
-
-**Returns:** `void`
-
-### showProjections
-
-Show cost projections based on current usage patterns
-
-**Method:** `function`
-
-**Returns:** `Promise<void>`
-
-### showRecommendations
-
-Show usage recommendations based on current patterns
-
-**Method:** `function`
-
-**Returns:** `Promise<void>`
-
-### runUsageCLI
-
-CLI entry point for usage commands
-
-**Method:** `function`
-
-**Parameters:**
-- `command` (string) - The command to execute
-- `args` (string[]) - Optional arguments for the command
-
-**Returns:** `Promise<void>`
 
 ### UsageTracker.startSession
 
@@ -264,94 +150,6 @@ UsageTracker method: getCurrentSessionMetrics
 
 **Returns:** `any`
 
-### UsageTracker.calculateOperationCost
-
-UsageTracker method: calculateOperationCost
-
-**Method:** `method`
-
-**Returns:** `any`
-
-### UsageTracker.generateMetricsId
-
-UsageTracker method: generateMetricsId
-
-**Method:** `method`
-
-**Returns:** `any`
-
-### UsageTracker.ensureDataDirectory
-
-UsageTracker method: ensureDataDirectory
-
-**Method:** `method`
-
-**Returns:** `any`
-
-### UsageTracker.persistMetrics
-
-UsageTracker method: persistMetrics
-
-**Method:** `method`
-
-**Returns:** `any`
-
-### UsageTracker.loadMetricsInRange
-
-UsageTracker method: loadMetricsInRange
-
-**Method:** `method`
-
-**Returns:** `any`
-
-### UsageTracker.cleanupOldMetrics
-
-UsageTracker method: cleanupOldMetrics
-
-**Method:** `method`
-
-**Returns:** `any`
-
-### UsageTracker.getEmptySummary
-
-UsageTracker method: getEmptySummary
-
-**Method:** `method`
-
-**Returns:** `any`
-
-### UsageCLI.showSummary
-
-UsageCLI method: showSummary
-
-**Method:** `method`
-
-**Returns:** `any`
-
-### UsageCLI.showCurrentSession
-
-UsageCLI method: showCurrentSession
-
-**Method:** `method`
-
-**Returns:** `any`
-
-### UsageCLI.showProjections
-
-UsageCLI method: showProjections
-
-**Method:** `method`
-
-**Returns:** `any`
-
-### UsageCLI.showRecommendations
-
-UsageCLI method: showRecommendations
-
-**Method:** `method`
-
-**Returns:** `any`
-
 ## New Features
 
 ### UsageTracker
@@ -359,14 +157,7 @@ UsageCLI method: showRecommendations
 Usage tracking system for cost monitoring and optimization
 
 **Category:** enhanced
-**Affected Files:** src/usage/tracker.ts, src/usage/types.ts, src/usage/cli.ts
-
-### UsageCLI
-
-CLI commands for usage tracking and cost monitoring
-
-**Category:** enhanced
-**Affected Files:** src/usage/tracker.ts, src/usage/types.ts, src/usage/cli.ts
+**Affected Files:** src/usage/tracker.ts
 
 ## Architectural Changes
 
@@ -377,16 +168,7 @@ CLI commands for usage tracking and cost monitoring
 
 Component modified: tracker
 
-### cli
-
-**Type:** component-modified
-**Impact:** medium
-
-Component modified: cli
-
 ## Changed Files
 
 - `src/usage/tracker.ts` (modified)
-- `src/usage/types.ts` (modified)
-- `src/usage/cli.ts` (modified)
 

--- a/.kiro/usage/usage-2026-01-13.json
+++ b/.kiro/usage/usage-2026-01-13.json
@@ -35,5 +35,79 @@
         "cost": 0
       }
     ]
+  },
+  {
+    "id": "metrics-1768290962074-qd8ash5yh",
+    "timestamp": "2026-01-13T07:56:02.074Z",
+    "sessionId": "session-1768290962074-clplzaauv",
+    "analysisRuns": 1,
+    "filesProcessed": 4,
+    "tokensConsumed": 130809,
+    "estimatedCost": 2.35457,
+    "executionTimeMs": 184894,
+    "operationBreakdown": [
+      {
+        "type": "analysis",
+        "count": 1,
+        "durationMs": 2,
+        "cost": 0
+      },
+      {
+        "type": "subagent",
+        "count": 2,
+        "durationMs": 153077,
+        "tokens": 130809,
+        "cost": 2.35457
+      },
+      {
+        "type": "template",
+        "count": 1,
+        "durationMs": 31807,
+        "cost": 0
+      },
+      {
+        "type": "file-write",
+        "count": 1,
+        "durationMs": 8,
+        "cost": 0
+      }
+    ]
+  },
+  {
+    "id": "metrics-1768291428322-vm8ioxrxx",
+    "timestamp": "2026-01-13T08:03:48.322Z",
+    "sessionId": "session-1768291428322-vmlv9g6dt",
+    "analysisRuns": 1,
+    "filesProcessed": 1,
+    "tokensConsumed": 38331,
+    "estimatedCost": 0.68997,
+    "executionTimeMs": 69996,
+    "operationBreakdown": [
+      {
+        "type": "analysis",
+        "count": 1,
+        "durationMs": 0,
+        "cost": 0
+      },
+      {
+        "type": "subagent",
+        "count": 2,
+        "durationMs": 39376,
+        "tokens": 38331,
+        "cost": 0.68997
+      },
+      {
+        "type": "template",
+        "count": 1,
+        "durationMs": 30613,
+        "cost": 0
+      },
+      {
+        "type": "file-write",
+        "count": 1,
+        "durationMs": 7,
+        "cost": 0
+      }
+    ]
   }
 ]

--- a/README.md
+++ b/README.md
@@ -1,62 +1,164 @@
-**Features:**
+# Auto-Doc-Sync
 
-- **Git Context Integration**: Integration of git context retrieval in the DevelopmentLogger class, including methods to get commit hash, author, branch, and check if inside a git repository.
-- **utils**: Added formatDate function (Date) → any
-- **manual-test**: Added processData function (string) → any
-- **orchestrator**: Updated AutoDocSyncSystem class with 1 methods
-- **AutoDocSyncSystem**: Main orchestration system that coordinates all components
-- **api**: Updated UserService class with 1 methods
-- **service**: Updated DataService class with 1 methods
-- **comprehensive-api**: Updated UserManagementService class with 1 methods
-- **feature**: Updated FeatureService class with 1 methods
+![Build Status](https://img.shields.io/badge/build-passing-brightgreen) ![Version](https://img.shields.io/badge/version-1.0.0-blue) ![License](https://img.shields.io/badge/license-MIT-green)
 
+## Autonomous Documentation Synchronization System for Kiro Projects
 
+Auto-Doc-Sync is an innovative system designed to automate the synchronization of documentation across Kiro projects. It ensures that your documentation is always up-to-date with the latest code changes, saving time and reducing errors.
 
-## Features & API
+## Overview
 
-**Features:**
+Auto-Doc-Sync addresses the common problem of outdated or inconsistent documentation in software projects. It is ideal for developers and project managers who need to maintain accurate documentation without the hassle of manual updates. By automating this process, Auto-Doc-Sync enhances productivity and ensures that all team members have access to the latest information.
 
-- **UsageTracker**: Usage tracking system for cost monitoring and optimization
-- **UsageCLI**: CLI commands for usage tracking and cost monitoring
+### Key Benefits
+- **Efficiency**: Automates the documentation update process, reducing manual effort.
+- **Accuracy**: Ensures documentation reflects the latest code changes.
+- **Collaboration**: Facilitates better communication among team members by providing up-to-date information.
 
-**API:**
+## Features
 
-- **startSession**(string) → Promise<void>: Start tracking a new session
-- **startOperation**(OperationMetrics['type'], string) → string: Track the start of an operation
-- **endOperation**(string, OperationMetrics['type'], number): Track the completion of an operation
-- **trackAnalysisRun**(number): Track analysis run completion
-- **checkCostThresholds**() → UsageAlert | null: Check if current session exceeds cost thresholds
-- **endSession**() → Promise<UsageMetrics | null>: End current session and persist metrics
-- **getUsageSummary**(number) → Promise<UsageSummary>: Get usage summary for a time period
-- **getCurrentSessionMetrics**() → Partial<UsageMetrics> | null: Get current session metrics
-- **calculateOperationCost**(OperationMetrics['type'], number) → number: Calculate cost for a specific operation
-- **generateMetricsId**() → string: Generate unique metrics ID
-- **ensureDataDirectory**() → Promise<void>: Ensure data directory exists
-- **persistMetrics**(UsageMetrics) → Promise<void>: Persist metrics to file
-- **loadMetricsInRange**(Date, Date) → Promise<UsageMetrics[]>: Load metrics within date range
-- **cleanupOldMetrics**() → Promise<void>: Clean up old metrics files
-- **getEmptySummary**() → UsageSummary: Get empty summary for when tracking is disabled or no data exists
-- **showSummary**(number) → Promise<void>: Display usage summary for the last N days
-- **showCurrentSession**(): Display current session metrics (if any)
-- **showProjections**() → Promise<void>: Show cost projections based on current usage patterns
-- **showRecommendations**() → Promise<void>: Show usage recommendations based on current patterns
-- **runUsageCLI**(string, string[]) → Promise<void>: CLI entry point for usage commands
-- **UsageTracker.startSession**() → any: UsageTracker method: startSession
-- **UsageTracker.startOperation**() → any: UsageTracker method: startOperation
-- **UsageTracker.endOperation**() → any: UsageTracker method: endOperation
-- **UsageTracker.trackAnalysisRun**() → any: UsageTracker method: trackAnalysisRun
-- **UsageTracker.checkCostThresholds**() → any: UsageTracker method: checkCostThresholds
-- **UsageTracker.endSession**() → any: UsageTracker method: endSession
-- **UsageTracker.getUsageSummary**() → any: UsageTracker method: getUsageSummary
-- **UsageTracker.getCurrentSessionMetrics**() → any: UsageTracker method: getCurrentSessionMetrics
-- **UsageTracker.calculateOperationCost**() → any: UsageTracker method: calculateOperationCost
-- **UsageTracker.generateMetricsId**() → any: UsageTracker method: generateMetricsId
-- **UsageTracker.ensureDataDirectory**() → any: UsageTracker method: ensureDataDirectory
-- **UsageTracker.persistMetrics**() → any: UsageTracker method: persistMetrics
-- **UsageTracker.loadMetricsInRange**() → any: UsageTracker method: loadMetricsInRange
-- **UsageTracker.cleanupOldMetrics**() → any: UsageTracker method: cleanupOldMetrics
-- **UsageTracker.getEmptySummary**() → any: UsageTracker method: getEmptySummary
-- **UsageCLI.showSummary**() → any: UsageCLI method: showSummary
-- **UsageCLI.showCurrentSession**() → any: UsageCLI method: showCurrentSession
-- **UsageCLI.showProjections**() → any: UsageCLI method: showProjections
-- **UsageCLI.showRecommendations**() → any: UsageCLI method: showRecommendations
+- **UsageTracker**: A comprehensive system for tracking usage metrics, monitoring costs, and optimizing resource allocation.
+- **UsageCLI**: Command-line interface for easy interaction with the usage tracking system, enabling quick setup and monitoring.
+- **Git Context Integration**: Seamlessly integrates with Git to retrieve context information, enhancing the documentation process.
+
+## Installation
+
+### Prerequisites
+- Node.js v14 or higher
+- npm (Node Package Manager)
+
+### Steps
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/yourusername/auto-doc-sync.git
+   ```
+2. Navigate to the project directory:
+   ```bash
+   cd auto-doc-sync
+   ```
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+### Verification
+Run the following command to ensure everything is set up correctly:
+```bash
+npm run test
+```
+
+## Quick Start
+
+To start using Auto-Doc-Sync, follow these simple steps:
+
+1. Initialize a new session:
+   ```javascript
+   const tracker = new UsageTracker();
+   tracker.startSession('session-123');
+   ```
+2. Track an operation:
+   ```javascript
+   const operationId = tracker.startOperation('analysis');
+   // Perform operation...
+   tracker.endOperation(operationId, 'analysis', 100);
+   ```
+3. End the session and persist metrics:
+   ```javascript
+   tracker.endSession().then(metrics => console.log(metrics));
+   ```
+
+## Configuration
+
+Auto-Doc-Sync can be configured via a configuration file located at `config/usage-config.json`.
+
+### Key Options
+- **enabled**: Enable or disable the tracking system.
+- **costLimitPerSession**: Set a cost limit for each session.
+- **costWarningThreshold**: Set a threshold for cost warnings.
+
+### Example Configuration
+```json
+{
+  "enabled": true,
+  "costLimitPerSession": 100,
+  "costWarningThreshold": 80
+}
+```
+
+## API Reference
+
+### UsageTracker
+
+- **startSession(sessionId: string): Promise<void>**
+  - Start tracking a new session.
+
+- **startOperation(operationType: string, operationId?: string): string**
+  - Begin tracking an operation.
+
+- **endOperation(operationId: string, operationType: string, tokens?: number): void**
+  - Complete tracking of an operation.
+
+- **trackAnalysisRun(filesProcessed: number): void**
+  - Record the completion of an analysis run.
+
+- **checkCostThresholds(): UsageAlert | null**
+  - Check if the current session exceeds cost thresholds.
+
+- **endSession(): Promise<UsageMetrics | null>**
+  - End the current session and save metrics.
+
+- **getUsageSummary(days: number): Promise<UsageSummary>**
+  - Retrieve a summary of usage over a specified period.
+
+## Examples
+
+### Example 1: Basic Usage Tracking
+```javascript
+const tracker = new UsageTracker();
+tracker.startSession('session-001');
+const opId = tracker.startOperation('analysis');
+// Perform some analysis...
+tracker.endOperation(opId, 'analysis', 150);
+tracker.endSession().then(metrics => console.log(metrics));
+```
+
+### Example 2: Cost Monitoring
+```javascript
+const tracker = new UsageTracker({ costLimitPerSession: 50 });
+tracker.startSession('session-002');
+// Perform operations...
+const alert = tracker.checkCostThresholds();
+if (alert) {
+  console.warn(alert.message);
+}
+tracker.endSession();
+```
+
+## Development
+
+### Contributing
+We welcome contributions! Please fork the repository and submit a pull request.
+
+### Running Tests
+To run tests, use:
+```bash
+npm test
+```
+
+### Development Setup
+1. Ensure all dependencies are installed:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+## Acknowledgments
+
+Special thanks to all contributors and the open-source community for their support and collaboration.

--- a/src/subagent/integration.ts
+++ b/src/subagent/integration.ts
@@ -250,6 +250,39 @@ export class SubagentIntegration {
   }
 
   /**
+   * Generate README using AI subagent
+   */
+  async generateReadme(
+    analysisResults: ChangeAnalysis,
+    existingContent?: string,
+    projectContext?: any
+  ): Promise<string> {
+    try {
+      // Check if OpenAI client is available
+      if (!process.env.OPENAI_API_KEY) {
+        console.warn('OPENAI_API_KEY not available, using fallback README generation');
+        return this.generateFallbackDocumentation(analysisResults, 'readme');
+      }
+
+      const response = await this.subagentClient.generateReadme({
+        analysisResults,
+        existingContent,
+        projectContext
+      });
+      
+      // Track tokens used
+      if (response.metadata?.tokensUsed) {
+        this.lastTokensUsed += response.metadata.tokensUsed;
+      }
+
+      return response.content;
+    } catch (error) {
+      console.warn('Subagent README generation failed:', error);
+      return this.generateFallbackDocumentation(analysisResults, 'readme');
+    }
+  }
+
+  /**
    * Process template using subagent
    */
   async processTemplate(

--- a/src/subagent/types.ts
+++ b/src/subagent/types.ts
@@ -23,7 +23,7 @@ export interface SubagentConfig {
 }
 
 export interface SubagentRequest {
-  type: 'code-analysis' | 'change-classification' | 'documentation-generation' | 'template-processing';
+  type: 'code-analysis' | 'change-classification' | 'documentation-generation' | 'template-processing' | 'readme-generation';
   payload: any;
   context?: SubagentContext;
 }
@@ -117,6 +117,30 @@ export interface TemplateProcessingResponse {
   processedContent: string;
   appliedVariables: string[];
   warnings?: string[];
+  metadata?: {
+    processingTime: number;
+    tokensUsed: number;
+    model: string;
+  };
+}
+
+export interface ReadmeGenerationRequest {
+  analysisResults: any;
+  existingContent?: string;
+  projectContext?: {
+    name?: string;
+    description?: string;
+    repository?: string;
+    license?: string;
+  };
+}
+
+export interface ReadmeGenerationResponse {
+  content: string;
+  sections: {
+    title: string;
+    content: string;
+  }[];
   metadata?: {
     processingTime: number;
     tokensUsed: number;


### PR DESCRIPTION
- Create comprehensive README generation prompt for subagent
- Add generateReadme method to SubagentIntegration
- Update orchestrator to use AI for README instead of templates
- Remove section-based updates for README (full file replacement)
- Add ReadmeGenerationRequest/Response types
- Integrate with usage tracking for token monitoring

Benefits:
- Generates professional, user-friendly README files
- Includes proper structure: title, badges, overview, installation, examples
- Organizes API reference logically (not just dumped)
- Adds context and explanations for features
- Creates scannable, actionable documentation

Example output:
- Project header with badges
- Clear value proposition
- Step-by-step installation
- Quick start with code examples
- Configuration guide
- Multiple usage examples
- Development instructions

Cost: ~/bin/zsh.70 per README generation (38k tokens)
Previous template approach: Just dumped API methods with no structure